### PR TITLE
Updated pipeline to push to OCP registry

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 trigger:
-- main
+- dev
 
 pool:
   vmImage: ubuntu-latest
@@ -21,52 +21,29 @@ stages:
       inputs:
 #        buildArguments: FEED_ACCESSTOKEN=$(FEED_ACCESSTOKEN)
         command: 'build'
-        Dockerfile: 'Dockerfile'
+        containerRegistry: 'kechung ROSA internal registry'
         buildContext: 'App'
         repository: '$(project-name-dev)/$(image-name)'
-    - task: ECRPushImage@1
-      name: ECRPushImageLatest
-      displayName: 'Push latest tag to AWS ECR'
+        Dockerfile: 'Dockerfile'
+        tags: $(Build.BuildId)
+    - task: Docker@2
+      displayName: 'Push Docker image to OpenShift internal registry'
       inputs:
-        awsCredentials: 'kechung AWS ECR'
-        regionName: 'us-east-1'
-        sourceImageName: '$(project-name-dev)/$(image-name)'
-        sourceImageTag: $(Build.BuildId)
-        repositoryName: '$(project-name-dev)/$(image-name)'
-        pushTag: 'latest'
-        autoCreateRepository: true
-    - task: ECRPushImage@1
-      name: ECRPushImageTag
-      displayName: 'Push unique tag to AWS ECR'
-      inputs:
-        awsCredentials: 'kechung AWS ECR'
-        regionName: 'us-east-1'
-        sourceImageName: '$(project-name-dev)/$(image-name)'
-        sourceImageTag: $(Build.BuildId)
-        repositoryName: '$(project-name-dev)/$(image-name)'
-        pushTag: '$(Build.BuildId)'
-        outputVariable: 'ecr-image'
-        autoCreateRepository: true
+        command: 'push'
+        containerRegistry: 'kechung ROSA internal registry'
+        repository: '$(project-name-dev)/$(image-name)'
+        tags: $(Build.BuildId)
     - task: PublishPipelineArtifact@1
       displayName: Publish pipeline artifacts
       inputs:
         targetPath: '$(Build.SourcesDirectory)/manifests'
         artifact: 'manifests'
         publishLocation: 'pipeline'
-    - task: PowerShell@2
-      displayName: Save variables for future stages
-      name: SaveVars
-      inputs:
-        targetType: 'inline'
-        script: |
-          echo "##vso[task.setvariable variable=ecr-image;isOutput=true]$(ecr-image)"
 
 - stage: Deploy
   displayName: Deploy to DEV
   dependsOn: Build
   condition: succeeded()
-  variables:
-    ecr-image: $[ stageDependencies.Build.BuildAndPushJob.outputs['SaveVars.ecr-image'] ]
   jobs:
   - job: DeployDevJob
     displayName: Deploy to DEV Job
@@ -79,4 +56,4 @@ stages:
         namespace: '$(project-name-dev)'
         manifests: |
           $(Build.SourcesDirectory)/manifests/kevin-dotnet.deployment.yaml
-        containers: '$(ecr-image)'
+        containers: 'image-registry.openshift-image-registry.svc:5000/$(project-name-dev)/$(image-name):$(Build.BuildId)'

--- a/manifests/kevin-dotnet.deployment.yaml
+++ b/manifests/kevin-dotnet.deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: kevin-dotnet
-          image: 015719942846.dkr.ecr.us-east-1.amazonaws.com/my-dev/kevin-dotnet
+          image: image-registry.openshift-image-registry.svc:5000/my-dev/kevin-dotnet
           ports:
             - containerPort: 8080
 


### PR DESCRIPTION
Updated Azure DevOps pipeline to push to OpenShift internal registry using service account. Docker registry service connection will need to be set up with credentials obtained from:
```
$ oc create sa azure-sa
$ oc sa get-token azure-sa
```